### PR TITLE
fix: overflow elipsis a username del podium

### DIFF
--- a/App/greeny/lib/Social/podium.dart
+++ b/App/greeny/lib/Social/podium.dart
@@ -74,6 +74,7 @@ class PodiumAvatar extends StatelessWidget {
               width: 110,
               child: Text(
                 username,
+                overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,
                 style: const TextStyle(fontSize: 20),
               ),


### PR DESCRIPTION
Arreglat error que si el username d'un usuari del podium era molt llarg es solapava amb la puntuació i la info de l'usuari.