### PR TITLE
fix: overflow punts i refresh ranking

### DIFF
--- a/App/greeny/lib/Social/podium.dart
+++ b/App/greeny/lib/Social/podium.dart
@@ -85,6 +85,7 @@ class PodiumAvatar extends StatelessWidget {
               width: 110,
               child: Text(
                 "${points.toString()} pts",
+                overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,
                 style: TextStyle(fontSize: 15, color: Colors.grey[600]),
               ),

--- a/App/greeny/lib/Social/rank.dart
+++ b/App/greeny/lib/Social/rank.dart
@@ -47,7 +47,7 @@ class _RankPageState extends State<RankPage> {
     } catch (e) {}
   }
 
-  void refresh() {
+  Future<void> refresh() async {
     getFriendsRequests();
     _fetchRanking();
   }
@@ -140,7 +140,7 @@ class _RankPageState extends State<RankPage> {
               child: CircularProgressIndicator(),
             )
           : RefreshIndicator(
-              onRefresh: getFriendsRequests,
+              onRefresh: refresh,
               child: Center(
                 child: Padding(
                   padding: const EdgeInsets.fromLTRB(20, 10, 20,


### PR DESCRIPTION
- Si els punts del podium fan overflow surt elipsis ... 
- Al fer swipe down a la llista del rankign es refresca el ranking i les friend requests.